### PR TITLE
front側でのログイン関連機能追加に伴うdevise token authの設定変更

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -1,3 +1,0 @@
-class Api::V1::ApplicationController < ActionController::API
-  include DeviseTokenAuth::Concerns::SetUserByToken
-end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
   private
 
     def sign_up_params
-      params.permit(:name, :email, :password, :password_confirmation)
+      params.permit(:name, :email, :password, :password_confirmation, :hr_constituency_id, :hc_constituency_id, :prefecture_id)
     end
 
     def account_update_params

--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::Auth::SessionsController < ApplicationController
+  def index
+    if current_api_v1_user
+      render json: { is_login: true, data: current_api_v1_user}
+    else
+      render json: { is_login: false, message: "ユーザーが存在しません" }
+    end
+  end
+end

--- a/app/controllers/api/v1/hc_constituencies_controller.rb
+++ b/app/controllers/api/v1/hc_constituencies_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::HcConstituenciesController < Api::V1::ApplicationController
+class Api::V1::HcConstituenciesController < ApplicationController
   def index
     hc_constituencies = HcConstituency.select(:id, :name, :quota)
     render json: hc_constituencies

--- a/app/controllers/api/v1/hc_members_controller.rb
+++ b/app/controllers/api/v1/hc_members_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::HcMembersController < Api::V1::ApplicationController
+class Api::V1::HcMembersController < ApplicationController
   # 選挙区ごとの参議院議員
   def index_of_hc_constituency
     active_hc_election_time_ids = HcElectionTime.pluck(:id).last(2)

--- a/app/controllers/api/v1/hr_members_controller.rb
+++ b/app/controllers/api/v1/hr_members_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::HrMembersController < Api::V1::ApplicationController
+class Api::V1::HrMembersController < ApplicationController
   # 都道府県ごとの小選挙区選出衆議院議員
   def index_of_prefecture
     latest_hr_election_time_id = HrElectionTime.last.id

--- a/app/controllers/api/v1/hr_pr_blocks_controller.rb
+++ b/app/controllers/api/v1/hr_pr_blocks_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::HrPrBlocksController < Api::V1::ApplicationController
+class Api::V1::HrPrBlocksController < ApplicationController
   def index
     hr_pr_blocks = HrPrBlock.select(:id, :block_name, :quota)
     render json: hr_pr_blocks

--- a/app/controllers/api/v1/political_parties_controller.rb
+++ b/app/controllers/api/v1/political_parties_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::PoliticalPartiesController < Api::V1::ApplicationController
+class Api::V1::PoliticalPartiesController < ApplicationController
   def show
     political_party = PoliticalParty.select(:id, :name_kanji, :name_kana, :abbreviation_kanji,
                                             :abbreviation_kana).where(id: params[:id])

--- a/app/controllers/api/v1/political_party_members_controller.rb
+++ b/app/controllers/api/v1/political_party_members_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::PoliticalPartyMembersController < Api::V1::ApplicationController
+class Api::V1::PoliticalPartyMembersController < ApplicationController
   def index_of_hr_members
     latest_hr_election_time_id = HrElectionTime.last.id
     hr_members = PoliticalPartyMember.political_party_hr_members(political_party_id: params[:id],

--- a/app/controllers/api/v1/prefectures_controller.rb
+++ b/app/controllers/api/v1/prefectures_controller.rb
@@ -1,4 +1,4 @@
-class Api::V1::PrefecturesController < Api::V1::ApplicationController
+class Api::V1::PrefecturesController < ApplicationController
   def index
     prefectures = Prefecture.select(:id, :prefecture)
     render json: prefectures

--- a/app/controllers/api/v1/tests_controller.rb
+++ b/app/controllers/api/v1/tests_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::TestsController < ApplicationController
+  before_action :authenticate_api_v1_user!
+
+  def index
+    render json: { message: 'hello' }
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::UsersController < ApplicationController
+  def index
+    # users = User.all
+    # render json: users
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,0 +1,3 @@
+class ApplicationController < ActionController::API
+  include DeviseTokenAuth::Concerns::SetUserByToken
+end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -6,10 +6,12 @@ DeviseTokenAuth.setup do |config|
   # this to false to prevent the Authorization header from changing after
   # each request.
   # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
   # config.token_lifespan = 2.weeks
+  config.token_lifespan = 2.weeks
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+
   namespace :api do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
@@ -36,6 +37,18 @@ Rails.application.routes.draw do
 
       controller :prefectures do
         resources :prefectures, only: [:index, :show]
+      end
+
+      # controller :users do
+      #   resources :users, only: [:index]
+      # end
+
+      controller :tests do
+        resources :tests, only: [:index]
+      end
+
+      namespace :auth do
+        resources :sessions, only: [:index]
       end
 
     end


### PR DESCRIPTION
# 概要
* devise token authの設定（config/initializers/devise_token_auth.rb）を変更
* application_controller.rbの配置をapp/controllers/api/v1配下からapp/controllers配下に変更（devise token authの機能に不具合が起きたため）
* 上記のapplication_controller.rbの配置変更に伴い、他controllerの継承元を変更
* 認証ユーザー情報を返すsessions_controllerを実装
* 認証トークン付きでリクエストしないと必要なデータを返さないコントローラーのテスト実装（tests_controller）